### PR TITLE
add flexible processing level support for single and multi-session datasets

### DIFF
--- a/ants-nidm_babs_script.sh
+++ b/ants-nidm_babs_script.sh
@@ -43,17 +43,7 @@ PROCESSING_LEVEL="${3:-subject}"  # Default to "subject" if not provided
 # Initialize run date (auto-generate or use env var)
 babs_init_run_date
 
-# Validate processing level
-if [ "$PROCESSING_LEVEL" != "subject" ] && [ "$PROCESSING_LEVEL" != "session" ]; then
-    echo "ERROR: processing_level must be either 'subject' or 'session'" >&2
-    echo "  Provided: '$PROCESSING_LEVEL'" >&2
-    echo "  Usage: $0 <site_name> <dataset_name> [processing_level]" >&2
-    echo "  Example: $0 Caltech study-ABIDE subject" >&2
-    echo "  Example: $0 Brown study-ADHD200 session" >&2
-    exit 1
-fi
-
-# Validate arguments
+# Validate arguments (includes processing level validation)
 babs_validate_args "$SITE_NAME" "$DATASET_NAME" "$PROCESSING_LEVEL"
 
 # ============================================================================

--- a/ants-nidm_babs_script.sh
+++ b/ants-nidm_babs_script.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 # ANTs-NIDM BABS Script
-# Usage: ./ants-nidm_babs_script.sh <site_name> <dataset_name>
-# Example: ./ants-nidm_babs_script.sh Caltech study-ABIDE
+# Usage: ./ants-nidm_babs_script.sh <site_name> <dataset_name> [processing_level]
 #
-# Optional: Set RUN_DATE environment variable to use a specific date instead of auto-generated
-#   export RUN_DATE=1230
-#   ./ants-nidm_babs_script.sh Caltech study-ABIDE
+# Arguments:
+#   site_name         - Site identifier (e.g., Caltech, Brown)
+#   dataset_name      - Dataset identifier (e.g., study-ABIDE, study-ADHD200)
+#   processing_level  - Optional: "subject" or "session" (default: subject)
+#
+# Examples:
+#   Single-session dataset:  ./ants-nidm_babs_script.sh Caltech study-ABIDE
+#   Multi-session dataset:   ./ants-nidm_babs_script.sh Brown study-ADHD200 session
+#
+# Optional environment variable:
+#   RUN_DATE=YYMMDD - Use specific date instead of auto-generated
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -31,12 +38,23 @@ SIF_ALT_PATHS=(
 # ============================================================================
 SITE_NAME="$1"
 DATASET_NAME="$2"
+PROCESSING_LEVEL="${3:-subject}"  # Default to "subject" if not provided
 
 # Initialize run date (auto-generate or use env var)
 babs_init_run_date
 
+# Validate processing level
+if [ "$PROCESSING_LEVEL" != "subject" ] && [ "$PROCESSING_LEVEL" != "session" ]; then
+    echo "ERROR: processing_level must be either 'subject' or 'session'" >&2
+    echo "  Provided: '$PROCESSING_LEVEL'" >&2
+    echo "  Usage: $0 <site_name> <dataset_name> [processing_level]" >&2
+    echo "  Example: $0 Caltech study-ABIDE subject" >&2
+    echo "  Example: $0 Brown study-ADHD200 session" >&2
+    exit 1
+fi
+
 # Validate arguments
-babs_validate_args "$SITE_NAME" "$DATASET_NAME"
+babs_validate_args "$SITE_NAME" "$DATASET_NAME" "$PROCESSING_LEVEL"
 
 # ============================================================================
 # Set up logging
@@ -44,6 +62,7 @@ babs_validate_args "$SITE_NAME" "$DATASET_NAME"
 babs_setup_logging "$SCRATCH_DIR" "$APP_NAME"
 echo "Environment: SCRATCH_DIR=$SCRATCH_DIR, BASE_DIR=$BASE_DIR"
 echo "Processing site: $SITE_NAME for dataset: $DATASET_NAME"
+echo "Processing level: $PROCESSING_LEVEL"
 
 # ============================================================================
 # Set up environment
@@ -112,7 +131,7 @@ babs_init_and_submit \
     "$CONTAINER_NAME" \
     "$CONFIG_PATH" \
     "$OUTPUT_DIR" \
-    "subject"
+    "$PROCESSING_LEVEL"
 
 # ============================================================================
 # Print completion message

--- a/babs_common.sh
+++ b/babs_common.sh
@@ -216,11 +216,21 @@ babs_print_completion() {
 babs_validate_args() {
     local site_name="$1"
     local dataset_name="$2"
-    local processing_level="$3"  # Optional, just for signature
+    local processing_level="$3"
 
     if [ -z "$site_name" ] || [ -z "$dataset_name" ]; then
-        echo "Error: Missing arguments. Usage: $0 <site_name> <dataset_name> [processing_level]"
-        echo "  processing_level: 'subject' (default) or 'session'"
+        echo "Error: Missing arguments. Usage: $0 <site_name> <dataset_name> [processing_level]" >&2
+        echo "  processing_level: 'subject' (default) or 'session'" >&2
+        exit 1
+    fi
+
+    # Validate processing level if provided
+    if [ -n "$processing_level" ] && [ "$processing_level" != "subject" ] && [ "$processing_level" != "session" ]; then
+        echo "ERROR: processing_level must be either 'subject' or 'session'" >&2
+        echo "  Provided: '$processing_level'" >&2
+        echo "  Usage: $0 <site_name> <dataset_name> [processing_level]" >&2
+        echo "  Example: $0 Caltech study-ABIDE subject" >&2
+        echo "  Example: $0 Brown study-ADHD200 session" >&2
         exit 1
     fi
 }

--- a/babs_common.sh
+++ b/babs_common.sh
@@ -212,13 +212,15 @@ babs_print_completion() {
 }
 
 # Validate arguments
-# Usage: babs_validate_args <site_name> <dataset_name>
+# Usage: babs_validate_args <site_name> <dataset_name> [processing_level]
 babs_validate_args() {
     local site_name="$1"
     local dataset_name="$2"
+    local processing_level="$3"  # Optional, just for signature
 
     if [ -z "$site_name" ] || [ -z "$dataset_name" ]; then
-        echo "Error: Missing arguments. Usage: $0 <site_name> <dataset_name>"
+        echo "Error: Missing arguments. Usage: $0 <site_name> <dataset_name> [processing_level]"
+        echo "  processing_level: 'subject' (default) or 'session'"
         exit 1
     fi
 }

--- a/freesurfer-nidm_babs_script.sh
+++ b/freesurfer-nidm_babs_script.sh
@@ -45,17 +45,7 @@ PROCESSING_LEVEL="${3:-subject}"  # Default to "subject" if not provided
 # Initialize run date (auto-generate or use env var)
 babs_init_run_date
 
-# Validate processing level
-if [ "$PROCESSING_LEVEL" != "subject" ] && [ "$PROCESSING_LEVEL" != "session" ]; then
-    echo "ERROR: processing_level must be either 'subject' or 'session'" >&2
-    echo "  Provided: '$PROCESSING_LEVEL'" >&2
-    echo "  Usage: $0 <site_name> <dataset_name> [processing_level]" >&2
-    echo "  Example: $0 Caltech study-ABIDE subject" >&2
-    echo "  Example: $0 Brown study-ADHD200 session" >&2
-    exit 1
-fi
-
-# Validate arguments
+# Validate arguments (includes processing level validation)
 babs_validate_args "$SITE_NAME" "$DATASET_NAME" "$PROCESSING_LEVEL"
 
 # ============================================================================

--- a/freesurfer-nidm_babs_script.sh
+++ b/freesurfer-nidm_babs_script.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 # FreeSurfer-NIDM BABS Script
-# Usage: ./freesurfer-nidm_babs_script.sh <site_name> <dataset_name>
-# Example: ./freesurfer-nidm_babs_script.sh Caltech study-ABIDE
+# Usage: ./freesurfer-nidm_babs_script.sh <site_name> <dataset_name> [processing_level]
 #
-# Optional: Set RUN_DATE environment variable to use a specific date instead of auto-generated
-#   export RUN_DATE=1230
-#   ./freesurfer-nidm_babs_script.sh Caltech study-ABIDE
+# Arguments:
+#   site_name         - Site identifier (e.g., Caltech, Brown)
+#   dataset_name      - Dataset identifier (e.g., study-ABIDE, study-ADHD200)
+#   processing_level  - Optional: "subject" or "session" (default: subject)
+#
+# Examples:
+#   Single-session dataset:  ./freesurfer-nidm_babs_script.sh Caltech study-ABIDE
+#   Multi-session dataset:   ./freesurfer-nidm_babs_script.sh Brown study-ADHD200 session
+#
+# Optional environment variable:
+#   RUN_DATE=YYMMDD - Use specific date instead of auto-generated
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -33,12 +40,23 @@ SIF_ALT_PATHS=(
 # ============================================================================
 SITE_NAME="$1"
 DATASET_NAME="$2"
+PROCESSING_LEVEL="${3:-subject}"  # Default to "subject" if not provided
 
 # Initialize run date (auto-generate or use env var)
 babs_init_run_date
 
+# Validate processing level
+if [ "$PROCESSING_LEVEL" != "subject" ] && [ "$PROCESSING_LEVEL" != "session" ]; then
+    echo "ERROR: processing_level must be either 'subject' or 'session'" >&2
+    echo "  Provided: '$PROCESSING_LEVEL'" >&2
+    echo "  Usage: $0 <site_name> <dataset_name> [processing_level]" >&2
+    echo "  Example: $0 Caltech study-ABIDE subject" >&2
+    echo "  Example: $0 Brown study-ADHD200 session" >&2
+    exit 1
+fi
+
 # Validate arguments
-babs_validate_args "$SITE_NAME" "$DATASET_NAME"
+babs_validate_args "$SITE_NAME" "$DATASET_NAME" "$PROCESSING_LEVEL"
 
 # ============================================================================
 # Set up logging
@@ -46,6 +64,7 @@ babs_validate_args "$SITE_NAME" "$DATASET_NAME"
 babs_setup_logging "$SCRATCH_DIR" "$APP_NAME"
 echo "Environment: SCRATCH_DIR=$SCRATCH_DIR, BASE_DIR=$BASE_DIR"
 echo "Processing site: $SITE_NAME for dataset: $DATASET_NAME"
+echo "Processing level: $PROCESSING_LEVEL"
 
 # ============================================================================
 # Set up environment
@@ -108,7 +127,7 @@ babs_init_and_submit \
     "$CONTAINER_NAME" \
     "$CONFIG_PATH" \
     "$OUTPUT_DIR" \
-    "subject"
+    "$PROCESSING_LEVEL"
 
 # ============================================================================
 # Print completion message

--- a/mriqc-nidm_babs_script.sh
+++ b/mriqc-nidm_babs_script.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 # MRIQC-NIDM BABS Script
-# Usage: ./mriqc-nidm_babs_script.sh <site_name> <dataset_name>
-# Example: ./mriqc-nidm_babs_script.sh Caltech study-ABIDE
+# Usage: ./mriqc-nidm_babs_script.sh <site_name> <dataset_name> [processing_level]
 #
-# Optional: Set RUN_DATE environment variable to use a specific date instead of auto-generated
-#   export RUN_DATE=1230
-#   ./mriqc-nidm_babs_script.sh Caltech study-ABIDE
+# Arguments:
+#   site_name         - Site identifier (e.g., Caltech, Brown)
+#   dataset_name      - Dataset identifier (e.g., study-ABIDE, study-ADHD200)
+#   processing_level  - Optional: "subject" or "session" (default: subject)
+#
+# Examples:
+#   Single-session dataset:  ./mriqc-nidm_babs_script.sh Caltech study-ABIDE
+#   Multi-session dataset:   ./mriqc-nidm_babs_script.sh Brown study-ADHD200 session
+#
+# Optional environment variable:
+#   RUN_DATE=YYMMDD - Use specific date instead of auto-generated
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -31,12 +38,23 @@ SIF_ALT_PATHS=(
 # ============================================================================
 SITE_NAME="$1"
 DATASET_NAME="$2"
+PROCESSING_LEVEL="${3:-subject}"  # Default to "subject" if not provided
 
 # Initialize run date (auto-generate or use env var)
 babs_init_run_date
 
+# Validate processing level
+if [ "$PROCESSING_LEVEL" != "subject" ] && [ "$PROCESSING_LEVEL" != "session" ]; then
+    echo "ERROR: processing_level must be either 'subject' or 'session'" >&2
+    echo "  Provided: '$PROCESSING_LEVEL'" >&2
+    echo "  Usage: $0 <site_name> <dataset_name> [processing_level]" >&2
+    echo "  Example: $0 Caltech study-ABIDE subject" >&2
+    echo "  Example: $0 Brown study-ADHD200 session" >&2
+    exit 1
+fi
+
 # Validate arguments
-babs_validate_args "$SITE_NAME" "$DATASET_NAME"
+babs_validate_args "$SITE_NAME" "$DATASET_NAME" "$PROCESSING_LEVEL"
 
 # ============================================================================
 # Set up logging
@@ -44,6 +62,7 @@ babs_validate_args "$SITE_NAME" "$DATASET_NAME"
 babs_setup_logging "$SCRATCH_DIR" "$APP_NAME"
 echo "Environment: SCRATCH_DIR=$SCRATCH_DIR, BASE_DIR=$BASE_DIR"
 echo "Processing site: $SITE_NAME for dataset: $DATASET_NAME"
+echo "Processing level: $PROCESSING_LEVEL"
 
 # ============================================================================
 # Set up environment
@@ -112,7 +131,7 @@ babs_init_and_submit \
     "$CONTAINER_NAME" \
     "$CONFIG_PATH" \
     "$OUTPUT_DIR" \
-    "subject"
+    "$PROCESSING_LEVEL"
 
 # ============================================================================
 # Print completion message

--- a/mriqc-nidm_babs_script.sh
+++ b/mriqc-nidm_babs_script.sh
@@ -43,17 +43,7 @@ PROCESSING_LEVEL="${3:-subject}"  # Default to "subject" if not provided
 # Initialize run date (auto-generate or use env var)
 babs_init_run_date
 
-# Validate processing level
-if [ "$PROCESSING_LEVEL" != "subject" ] && [ "$PROCESSING_LEVEL" != "session" ]; then
-    echo "ERROR: processing_level must be either 'subject' or 'session'" >&2
-    echo "  Provided: '$PROCESSING_LEVEL'" >&2
-    echo "  Usage: $0 <site_name> <dataset_name> [processing_level]" >&2
-    echo "  Example: $0 Caltech study-ABIDE subject" >&2
-    echo "  Example: $0 Brown study-ADHD200 session" >&2
-    exit 1
-fi
-
-# Validate arguments
+# Validate arguments (includes processing level validation)
 babs_validate_args "$SITE_NAME" "$DATASET_NAME" "$PROCESSING_LEVEL"
 
 # ============================================================================


### PR DESCRIPTION
Adds optional processing_level parameter to all BABS scripts, allowing users to specify "subject" (default) or "session" processing levels. This enables proper handling of both single-session datasets (e.g., ABIDE) and multi-session datasets (e.g., ADHD200).

Changes:
- Add optional 3rd argument [processing_level] to all three BABS scripts
- Default to "subject" for backwards compatibility
- Add validation with helpful error messages
- Update usage documentation in script headers
- Display processing level in logs for transparency