### PR TITLE
Tighten argument validation across wrapper scripts

### DIFF
--- a/ants-nidm_babs_script.sh
+++ b/ants-nidm_babs_script.sh
@@ -36,15 +36,10 @@ SIF_ALT_PATHS=(
 # ============================================================================
 # Parse arguments
 # ============================================================================
-SITE_NAME="$1"
-DATASET_NAME="$2"
-PROCESSING_LEVEL="${3:-subject}"  # Default to "subject" if not provided
+babs_parse_args "$@"
 
 # Initialize run date (auto-generate or use env var)
 babs_init_run_date
-
-# Validate arguments (includes processing level validation)
-babs_validate_args "$SITE_NAME" "$DATASET_NAME" "$PROCESSING_LEVEL"
 
 # ============================================================================
 # Set up logging

--- a/babs_common.sh
+++ b/babs_common.sh
@@ -211,6 +211,15 @@ babs_print_completion() {
     echo "Log file: $LOG_FILE" | tee -a "$LOG_FILE"
 }
 
+# Print usage and examples to stderr. Call after an "ERROR: ..." line in any
+# arg-handling failure path so users see a consistent message.
+babs_print_usage() {
+    echo "  Usage: $0 <site_name> <dataset_name> [processing_level]" >&2
+    echo "    processing_level: 'subject' (default) or 'session'" >&2
+    echo "  Example: $0 Caltech study-ABIDE subject" >&2
+    echo "  Example: $0 Brown study-ADHD200 session" >&2
+}
+
 # Validate arguments
 # Usage: babs_validate_args <site_name> <dataset_name> <processing_level>
 # processing_level must be "subject" or "session" (no empty allowed; callers
@@ -221,17 +230,14 @@ babs_validate_args() {
     local processing_level="$3"
 
     if [ -z "$site_name" ] || [ -z "$dataset_name" ]; then
-        echo "ERROR: Missing arguments. Usage: $0 <site_name> <dataset_name> [processing_level]" >&2
-        echo "  processing_level: 'subject' (default) or 'session'" >&2
+        echo "ERROR: Missing arguments." >&2
+        babs_print_usage
         exit 1
     fi
 
     if [ "$processing_level" != "subject" ] && [ "$processing_level" != "session" ]; then
-        echo "ERROR: processing_level must be either 'subject' or 'session'" >&2
-        echo "  Provided: '$processing_level'" >&2
-        echo "  Usage: $0 <site_name> <dataset_name> [processing_level]" >&2
-        echo "  Example: $0 Caltech study-ABIDE subject" >&2
-        echo "  Example: $0 Brown study-ADHD200 session" >&2
+        echo "ERROR: processing_level must be either 'subject' or 'session' (provided: '$processing_level')" >&2
+        babs_print_usage
         exit 1
     fi
 }
@@ -241,7 +247,8 @@ babs_validate_args() {
 # Usage: babs_parse_args "$@"
 babs_parse_args() {
     if [ "$#" -gt 3 ]; then
-        echo "ERROR: Too many arguments ($#). Usage: $0 <site_name> <dataset_name> [processing_level]" >&2
+        echo "ERROR: Too many arguments ($#)." >&2
+        babs_print_usage
         exit 1
     fi
 

--- a/babs_common.sh
+++ b/babs_common.sh
@@ -212,20 +212,21 @@ babs_print_completion() {
 }
 
 # Validate arguments
-# Usage: babs_validate_args <site_name> <dataset_name> [processing_level]
+# Usage: babs_validate_args <site_name> <dataset_name> <processing_level>
+# processing_level must be "subject" or "session" (no empty allowed; callers
+# should default to "subject" before passing in).
 babs_validate_args() {
     local site_name="$1"
     local dataset_name="$2"
     local processing_level="$3"
 
     if [ -z "$site_name" ] || [ -z "$dataset_name" ]; then
-        echo "Error: Missing arguments. Usage: $0 <site_name> <dataset_name> [processing_level]" >&2
+        echo "ERROR: Missing arguments. Usage: $0 <site_name> <dataset_name> [processing_level]" >&2
         echo "  processing_level: 'subject' (default) or 'session'" >&2
         exit 1
     fi
 
-    # Validate processing level if provided
-    if [ -n "$processing_level" ] && [ "$processing_level" != "subject" ] && [ "$processing_level" != "session" ]; then
+    if [ "$processing_level" != "subject" ] && [ "$processing_level" != "session" ]; then
         echo "ERROR: processing_level must be either 'subject' or 'session'" >&2
         echo "  Provided: '$processing_level'" >&2
         echo "  Usage: $0 <site_name> <dataset_name> [processing_level]" >&2
@@ -233,4 +234,20 @@ babs_validate_args() {
         echo "  Example: $0 Brown study-ADHD200 session" >&2
         exit 1
     fi
+}
+
+# Parse positional arguments for the wrapper scripts.
+# Sets globals: SITE_NAME, DATASET_NAME, PROCESSING_LEVEL.
+# Usage: babs_parse_args "$@"
+babs_parse_args() {
+    if [ "$#" -gt 3 ]; then
+        echo "ERROR: Too many arguments ($#). Usage: $0 <site_name> <dataset_name> [processing_level]" >&2
+        exit 1
+    fi
+
+    SITE_NAME="$1"
+    DATASET_NAME="$2"
+    PROCESSING_LEVEL="${3:-subject}"
+
+    babs_validate_args "$SITE_NAME" "$DATASET_NAME" "$PROCESSING_LEVEL"
 }

--- a/freesurfer-nidm_babs_script.sh
+++ b/freesurfer-nidm_babs_script.sh
@@ -38,15 +38,10 @@ SIF_ALT_PATHS=(
 # ============================================================================
 # Parse arguments
 # ============================================================================
-SITE_NAME="$1"
-DATASET_NAME="$2"
-PROCESSING_LEVEL="${3:-subject}"  # Default to "subject" if not provided
+babs_parse_args "$@"
 
 # Initialize run date (auto-generate or use env var)
 babs_init_run_date
-
-# Validate arguments (includes processing level validation)
-babs_validate_args "$SITE_NAME" "$DATASET_NAME" "$PROCESSING_LEVEL"
 
 # ============================================================================
 # Set up logging

--- a/mriqc-nidm_babs_script.sh
+++ b/mriqc-nidm_babs_script.sh
@@ -36,15 +36,10 @@ SIF_ALT_PATHS=(
 # ============================================================================
 # Parse arguments
 # ============================================================================
-SITE_NAME="$1"
-DATASET_NAME="$2"
-PROCESSING_LEVEL="${3:-subject}"  # Default to "subject" if not provided
+babs_parse_args "$@"
 
 # Initialize run date (auto-generate or use env var)
 babs_init_run_date
-
-# Validate arguments (includes processing level validation)
-babs_validate_args "$SITE_NAME" "$DATASET_NAME" "$PROCESSING_LEVEL"
 
 # ============================================================================
 # Set up logging


### PR DESCRIPTION
## Summary

Three small follow-ups from a retrospective review of #3:

- **Drop the redundant `-n` guard** in `babs_validate_args` so an empty `processing_level` is rejected rather than silently accepted. Callers always default to `subject` via `${3:-subject}`, but the guard concealed a footgun for any future direct caller.
- **Normalize error-prefix casing**: both failure messages in `babs_validate_args` now use `ERROR:` (previously a mix of `Error:` and `ERROR:`).
- **Extract `babs_parse_args` helper** to centralize the duplicated arg-parsing block across the three wrapper scripts. The helper enforces `[ "$#" -le 3 ]` (rejects extra positional args), defaults `PROCESSING_LEVEL` to `subject`, and calls `babs_validate_args`. Each wrapper script now just runs `babs_parse_args "$@"`.

## Why

After the processing-level addition in #3, the three wrapper scripts each carry an identical 4-line parse block — the kind of low-grade duplication that drifts the next time anyone adds a positional arg. Centralizing it in `babs_common.sh` (where `babs_init_run_date` already sets globals by the same convention) keeps the wrappers thin and makes future positional-arg changes a one-file edit.

The validator hardening is independent but cheap to bundle: it converts a "shouldn't happen in practice" empty case into an actual error, and tidies up the inconsistent error prefix.

## What changed

- `babs_common.sh`:
  - `babs_validate_args`: removed the `-n "$processing_level"` clause; updated the function comment to document that `processing_level` is now required (callers should default before calling); changed `Error:` → `ERROR:` for consistency.
  - New `babs_parse_args` function: sets `SITE_NAME` / `DATASET_NAME` / `PROCESSING_LEVEL` globals, rejects `> 3` args, then calls `babs_validate_args`.
- `ants-nidm_babs_script.sh`, `freesurfer-nidm_babs_script.sh`, `mriqc-nidm_babs_script.sh`:
  - Replaced the inline `SITE_NAME=...; DATASET_NAME=...; PROCESSING_LEVEL=${3:-subject}; ...; babs_validate_args ...` block with a single `babs_parse_args "$@"` call.

Net diff: +24 / -22 across 4 files.

## Test plan

Manually verified the three failure paths against `ants-nidm_babs_script.sh` (parser logic is shared via `babs_common.sh`, so the other two scripts behave identically):

- [x] No args → `ERROR: Missing arguments. Usage: ...`
- [x] Invalid processing_level (`Caltech study-ABIDE bogus`) → `ERROR: processing_level must be either 'subject' or 'session'`
- [x] Too many args (`A B subject EXTRA`) → `ERROR: Too many arguments (4). Usage: ...`
- [x] `bash -n` clean on `babs_common.sh` and all three wrapper scripts.
- [ ] Run one real pipeline end-to-end with valid args to confirm no regression (out of scope for the CI-less repo; reviewer can spot-check).

## Notes for the reviewer

- Stacks on top of `main`; independent of #5 (the FreeSurfer license parameterization). Whichever merges first, the other will need a one-line rebase in `freesurfer-nidm_babs_script.sh` — the FS_LICENSE validation block sits just after the args parsing and is unaffected by the refactor itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)