### PR TITLE
Update BABS project layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,27 @@ babs status
 babs merge
 ```
 
+## BABS project layout
+
+The supplied configs use the configurable BIDS-study layout introduced by
+[PennLINC/babs PR #369](https://github.com/PennLINC/babs/pull/369):
+
+```yaml
+analysis_path: "."
+input_ria_path: ".babs/input_ria"
+output_ria_path: ".babs/output_ria"
+```
+
+The project directory is therefore the analysis DataLad dataset, input
+datasets are installed beneath `sourcedata/`, and internal RIA stores live
+beneath `.babs/`. Use a BABS revision containing PR #369 with these configs.
+To create a project with BABS's legacy layout instead, remove the three path
+settings; `post_babs.sh` supports both output RIA locations.
+
+For session-level runs, the wrappers add
+`$SESSION_SELECTION_FLAG: "--session-label"` to the generated config. They omit
+it for subject-level runs because BABS only defines `$sesid` in session jobs.
+
 ## Post-Processing
 
 After jobs complete, use the post-processing script:

--- a/ants-nidm_babs_script.sh
+++ b/ants-nidm_babs_script.sh
@@ -98,6 +98,8 @@ babs_prepare_yaml_config \
     "COMPUTE_SPACE=${COMPUTE_DIR}" \
     "RUN_DATE=${RUN_DATE}"
 
+babs_configure_session_selection "$CONFIG_PATH" "$PROCESSING_LEVEL" || exit 1
+
 echo "BIDS origin URL: $BIDS_ORIGIN"
 echo "NIDM origin URL: $NIDM_ORIGIN"
 

--- a/babs_common.sh
+++ b/babs_common.sh
@@ -216,17 +216,37 @@ babs_init_and_submit() {
 
     cd "${output_dir}" || exit 1
 
-    # Optional: First check the setup before submitting
-    echo "Checking BABS setup..."
-    babs check-setup "${PWD}" --job_test
+    # Check the setup before submitting.
+    #
+    # NOTE: `babs check-setup` currently crashes on the PR #369 BIDS-study layout
+    # (analysis_path=".", inputs under sourcedata/). check_setup.py hardcodes a
+    # pre-check on `<analysis_path>/inputs/data` that does not exist in that
+    # layout, raising FileNotFoundError before it reaches the real per-input-
+    # dataset validation. That pre-check is redundant with the per-dataset loop
+    # that follows it, so bypassing check-setup here does not lose validation of
+    # the input datasets themselves. Set BABS_SKIP_CHECK_SETUP=1 to skip it for
+    # study-layout projects until babs fixes check_setup.py upstream.
+    local check_setup_ok=0
+    if [ "${BABS_SKIP_CHECK_SETUP:-0}" = "1" ]; then
+        echo "BABS_SKIP_CHECK_SETUP=1: skipping 'babs check-setup'"
+        echo "  (works around babs check_setup.py hardcoded 'inputs/data' check"
+        echo "   that is incompatible with the PR #369 BIDS-study layout)."
+        check_setup_ok=1
+    else
+        echo "Checking BABS setup..."
+        if babs check-setup "${PWD}" --job_test; then
+            check_setup_ok=1
+        fi
+    fi
 
-    # If babs check-setup is successful, submit all jobs
-    if [ $? -eq 0 ]; then
-        echo "BABS setup check successful, submitting all jobs..."
+    if [ "$check_setup_ok" -eq 1 ]; then
+        echo "Submitting all jobs..."
         babs submit
     else
         echo "BABS setup check failed. Please review the errors above."
-        echo "You can manually submit after fixing issues with: babs submit --all"
+        echo "If this is the known study-layout check_setup bug (FileNotFoundError"
+        echo "on '<project>/inputs/data'), re-run with BABS_SKIP_CHECK_SETUP=1."
+        echo "Or submit manually after review with: babs submit"
         exit 1
     fi
 }

--- a/babs_common.sh
+++ b/babs_common.sh
@@ -152,6 +152,32 @@ babs_prepare_yaml_config() {
     echo "YAML config file created at $output_path"
 }
 
+# Add BABS's session placeholder only for session-wise projects. BABS defines
+# $sesid in session job scripts, but not in subject job scripts.
+# Usage: babs_configure_session_selection <config_path> <processing_level>
+babs_configure_session_selection() {
+    local config_path="$1"
+    local processing_level="$2"
+
+    if [ ! -f "$config_path" ]; then
+        echo "ERROR: Config file not found: $config_path" >&2
+        return 1
+    fi
+
+    # Make repeated wrapper runs deterministic if a generated config is reused.
+    sed -i '/^[[:space:]]*\$SESSION_SELECTION_FLAG:/d' "$config_path"
+
+    if [ "$processing_level" = "session" ]; then
+        if ! grep -q '^[[:space:]]*\$SUBJECT_SELECTION_FLAG:' "$config_path"; then
+            echo "ERROR: \$SUBJECT_SELECTION_FLAG not found in $config_path" >&2
+            return 1
+        fi
+        sed -i \
+            '/^[[:space:]]*\$SUBJECT_SELECTION_FLAG:/a\    $SESSION_SELECTION_FLAG: "--session-label"' \
+            "$config_path"
+    fi
+}
+
 # Check NIDM directory for incremental building
 # Usage: babs_check_nidm <dataset_name> <site_name>
 babs_check_nidm() {

--- a/babs_common.sh
+++ b/babs_common.sh
@@ -137,10 +137,13 @@ babs_prepare_yaml_config() {
         local var="${subst%%=*}"
         local value="${subst#*=}"
 
-        # Escape special characters in the replacement value for sed
-        # Replace \ with \\, & with \&, and / with \/
+        # Escape only the characters that are special in a sed *replacement*:
+        # backslash, ampersand, and the '/' delimiter. Regex metacharacters such
+        # as '.' must NOT be escaped here (this is replacement text, not a
+        # pattern) or they leak literal backslashes into the config, e.g.
+        # "license.txt" -> "license\.txt". Escape backslash first.
         local escaped_value
-        escaped_value=$(printf '%s\n' "$value" | sed 's/[[\.*^$()+?{|]/\\&/g; s/&/\\&/g; s/\\/\\\\/g; s/\//\\\//g')
+        escaped_value=$(printf '%s' "$value" | sed -e 's/\\/\\\\/g' -e 's/&/\\&/g' -e 's/\//\\\//g')
 
         # Replace both ${VAR} and $VAR forms
         sed -i "s/\${${var}}/${escaped_value}/g" "$output_path"

--- a/config_ants-nidm.yaml
+++ b/config_ants-nidm.yaml
@@ -1,4 +1,9 @@
 # This is a config yaml file for ANTs BIDS App
+# BABS project layout (requires a BABS revision containing PennLINC/babs#369)
+analysis_path: "."
+input_ria_path: ".babs/input_ria"
+output_ria_path: ".babs/output_ria"
+
 # Input datasets configuration
 input_datasets:
     BIDS:
@@ -6,16 +11,16 @@ input_datasets:
             - "anat/*_T1w.nii*"
         is_zipped: false
         origin_url: "${BIDS_ORIGIN}"
-        path_in_babs: inputs/data/BIDS
+        path_in_babs: sourcedata/BIDS
     NIDM:
         required_files:
             - "nidm.ttl"
         is_zipped: false
         origin_url: "${NIDM_ORIGIN}"
-        path_in_babs: inputs/data/NIDM
+        path_in_babs: sourcedata/NIDM
 # Arguments passed to the application inside the container
 bids_app_args:
-    $SUBJECT_SELECTION_FLAG: "--participant_label"
+    $SUBJECT_SELECTION_FLAG: "--participant-label"
     --num-threads: "8"
 singularity_args:
     - --userns

--- a/config_freesurfer-nidm.yaml
+++ b/config_freesurfer-nidm.yaml
@@ -28,17 +28,29 @@ singularity_args:
     - --userns
     - --no-home
     - --writable-tmpfs
-# Output foldername(s) to be zipped:
+# Output foldername(s) to be zipped. The app writes <output>/sub-<id>/... with
+# no app-name wrapper (per-subject layout, ae9518a). ${subid} is NOT substituted
+# by babs_prepare_yaml_config (only vars passed to it are); it survives into the
+# rendered participant_job.sh where bash defines ${subid} at runtime, so each
+# job zips its own subject folder: sub-<id>_sub-<id>-0-1-0.zip.
 zip_foldernames:
-    freesurfer-nidm_bidsapp: "0-1-0"
+    ${subid}: "0-1-0"
 # How much cluster resources it needs:
 cluster_resources:
     interpreting_shell: "/bin/bash"
+    # Do NOT use mit_preemptable: a preempted BABS job is guaranteed to fail on
+    # requeue, because participant_job.sh does a bare `mkdir "${BRANCH}"` (no -p)
+    # and the branch dir already exists from the killed attempt. sub-0051457 hit
+    # this on the aug20 run.
+    # mem: both aug20 subjects peaked at MaxRSS ~23.99 GB against a 24G request,
+    # i.e. right at the ceiling — 32G gives real headroom.
+    # time: 03:30:00 was not enough; sub-0051457 hit the wall on a ~2x-slow node.
+    # The aug20 run completed at 06:00:00 (fastest subject used 47 min).
     customized_text: |
-        #SBATCH --partition=mit_preemptable
+        #SBATCH --partition=mit_normal
         #SBATCH --cpus-per-task=8
-        #SBATCH --mem=24G
-        #SBATCH --time=03:30:00
+        #SBATCH --mem=32G
+        #SBATCH --time=06:00:00
         #SBATCH --job-name=fs-nidm_bidsapp_${RUN_DATE}
 # Necessary commands to be run first:
 script_preamble: |

--- a/config_freesurfer-nidm.yaml
+++ b/config_freesurfer-nidm.yaml
@@ -21,7 +21,7 @@ input_datasets:
 # Arguments passed to the application inside the container
 bids_app_args:
     $SUBJECT_SELECTION_FLAG: "--participant-label"
-    --fs-license-file: "/orcd/scratch/bcs/001/yibei/prettymouth_babs/license.txt"
+    --fs-license-file: "${FS_LICENSE}"
     --skip-bids-validation: ""
     # Note: NIDM will be generated automatically if NIDM/ directory exists
 singularity_args:

--- a/config_freesurfer-nidm.yaml
+++ b/config_freesurfer-nidm.yaml
@@ -1,4 +1,9 @@
 # This is a config yaml file for FreeSurfer BIDS App
+# BABS project layout (requires a BABS revision containing PennLINC/babs#369)
+analysis_path: "."
+input_ria_path: ".babs/input_ria"
+output_ria_path: ".babs/output_ria"
+
 # Input datasets configuration
 input_datasets:
     BIDS:
@@ -6,16 +11,16 @@ input_datasets:
             - "anat/*_T1w.nii*"
         is_zipped: false
         origin_url: "${BIDS_ORIGIN}"
-        path_in_babs: inputs/data/BIDS
+        path_in_babs: sourcedata/BIDS
     NIDM:
         required_files:
             - "nidm.ttl"
         is_zipped: false
         origin_url: "${NIDM_ORIGIN}"
-        path_in_babs: inputs/data/NIDM
+        path_in_babs: sourcedata/NIDM
 # Arguments passed to the application inside the container
 bids_app_args:
-    "$SUBJECT_SELECTION_FLAG": "--participant_label"
+    $SUBJECT_SELECTION_FLAG: "--participant-label"
     --fs-license-file: "/orcd/scratch/bcs/001/yibei/prettymouth_babs/license.txt"
     --skip-bids-validation: ""
     # Note: NIDM will be generated automatically if NIDM/ directory exists

--- a/config_mriqc-nidm.yaml
+++ b/config_mriqc-nidm.yaml
@@ -1,4 +1,9 @@
 # This is a config yaml file for MRIQC BIDS App
+# BABS project layout (requires a BABS revision containing PennLINC/babs#369)
+analysis_path: "."
+input_ria_path: ".babs/input_ria"
+output_ria_path: ".babs/output_ria"
+
 # Input datasets configuration
 input_datasets:
     BIDS:
@@ -6,16 +11,16 @@ input_datasets:
             - "anat/*_T1w.nii*"
         is_zipped: false
         origin_url: "${BIDS_ORIGIN}"
-        path_in_babs: inputs/data/BIDS
+        path_in_babs: sourcedata/BIDS
     NIDM:
         required_files:
             - "nidm.ttl"
         is_zipped: false
         origin_url: "${NIDM_ORIGIN}"
-        path_in_babs: inputs/data/NIDM
+        path_in_babs: sourcedata/NIDM
 # Arguments passed to the application inside the container
 bids_app_args:
-    $SUBJECT_SELECTION_FLAG: "--participant_label"
+    $SUBJECT_SELECTION_FLAG: "--participant-label"
     --mem: "16G"
     --nprocs: "12"
     --omp-nthreads: "8"

--- a/freesurfer-nidm_babs_script.sh
+++ b/freesurfer-nidm_babs_script.sh
@@ -43,6 +43,16 @@ babs_parse_args "$@"
 # Initialize run date (auto-generate or use env var)
 babs_init_run_date
 
+# Validate FreeSurfer license (fail fast before submitting jobs)
+if [ -z "${FS_LICENSE:-}" ]; then
+    echo "ERROR: FS_LICENSE is not set. Add 'FS_LICENSE=/path/to/license.txt' to .env" >&2
+    exit 1
+fi
+if [ ! -f "$FS_LICENSE" ]; then
+    echo "ERROR: FreeSurfer license file not found at FS_LICENSE=$FS_LICENSE" >&2
+    exit 1
+fi
+
 # ============================================================================
 # Set up logging
 # ============================================================================
@@ -92,7 +102,8 @@ babs_prepare_yaml_config \
     "BIDS_ORIGIN=${BIDS_ORIGIN}" \
     "NIDM_ORIGIN=${NIDM_ORIGIN}" \
     "COMPUTE_SPACE=${COMPUTE_DIR}" \
-    "RUN_DATE=${RUN_DATE}"
+    "RUN_DATE=${RUN_DATE}" \
+    "FS_LICENSE=${FS_LICENSE}"
 
 babs_configure_session_selection "$CONFIG_PATH" "$PROCESSING_LEVEL" || exit 1
 

--- a/freesurfer-nidm_babs_script.sh
+++ b/freesurfer-nidm_babs_script.sh
@@ -94,6 +94,8 @@ babs_prepare_yaml_config \
     "COMPUTE_SPACE=${COMPUTE_DIR}" \
     "RUN_DATE=${RUN_DATE}"
 
+babs_configure_session_selection "$CONFIG_PATH" "$PROCESSING_LEVEL" || exit 1
+
 echo "BIDS origin URL: $BIDS_ORIGIN"
 echo "NIDM origin URL: $NIDM_ORIGIN"
 

--- a/mriqc-nidm_babs_script.sh
+++ b/mriqc-nidm_babs_script.sh
@@ -98,6 +98,8 @@ babs_prepare_yaml_config \
     "COMPUTE_SPACE=${COMPUTE_DIR}" \
     "RUN_DATE=${RUN_DATE}"
 
+babs_configure_session_selection "$CONFIG_PATH" "$PROCESSING_LEVEL" || exit 1
+
 echo "BIDS origin URL: $BIDS_ORIGIN"
 echo "NIDM origin URL: $NIDM_ORIGIN"
 

--- a/post_babs.sh
+++ b/post_babs.sh
@@ -63,8 +63,18 @@ echo "  DATASET: $DATASET"
 echo "  SITE: $SITE"
 echo "  TARGET_DIR: $TARGET_DIR"
 
-# RIA store lives under .../output_ria#~data
-RIA_URL="ria+file://${BABS_RUN_DIR}/output_ria#~data"
+# PR #369 projects keep internal RIA stores under .babs/. Retain support for
+# projects created with BABS's legacy top-level output_ria default.
+if [ -d "${BABS_RUN_DIR}/.babs/output_ria" ]; then
+  OUTPUT_RIA_DIR="${BABS_RUN_DIR}/.babs/output_ria"
+elif [ -d "${BABS_RUN_DIR}/output_ria" ]; then
+  OUTPUT_RIA_DIR="${BABS_RUN_DIR}/output_ria"
+else
+  echo "ERROR: No output RIA found under $BABS_RUN_DIR" >&2
+  echo "Checked .babs/output_ria and output_ria" >&2
+  exit 1
+fi
+RIA_URL="ria+file://${OUTPUT_RIA_DIR}#~data"
 
 # sanity checks
 command -v datalad >/dev/null || { echo "ERROR: datalad not found"; exit 1; }

--- a/tests/test_babs_pr369.sh
+++ b/tests/test_babs_pr369.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+cd "$REPO_ROOT"
+source "$REPO_ROOT/babs_common.sh"
+
+for template in "$REPO_ROOT"/config_*-nidm.yaml; do
+    config_path="$TEST_TMPDIR/$(basename "$template")"
+    babs_prepare_yaml_config \
+        "$template" \
+        "$config_path" \
+        "BIDS_ORIGIN=/tmp/BIDS" \
+        "NIDM_ORIGIN=/tmp/NIDM" \
+        "COMPUTE_SPACE=/tmp/compute" \
+        "RUN_DATE=260722"
+
+    grep -q '^analysis_path: "\."$' "$config_path"
+    grep -q '^input_ria_path: "\.babs/input_ria"$' "$config_path"
+    grep -q '^output_ria_path: "\.babs/output_ria"$' "$config_path"
+    grep -q 'path_in_babs: sourcedata/BIDS' "$config_path"
+    grep -q 'path_in_babs: sourcedata/NIDM' "$config_path"
+
+    babs_configure_session_selection "$config_path" subject
+    if grep -q '^[[:space:]]*\$SESSION_SELECTION_FLAG:' "$config_path"; then
+        echo "Session selection leaked into subject config: $config_path" >&2
+        exit 1
+    fi
+
+    babs_configure_session_selection "$config_path" session
+    test "$(grep -c '^[[:space:]]*\$SESSION_SELECTION_FLAG: "--session-label"$' "$config_path")" -eq 1
+
+    # Reconfiguration must be idempotent.
+    babs_configure_session_selection "$config_path" session
+    test "$(grep -c '^[[:space:]]*\$SESSION_SELECTION_FLAG: "--session-label"$' "$config_path")" -eq 1
+done
+
+echo "BABS PR #369 configuration checks passed"


### PR DESCRIPTION
## Summary

- opt all ANTs, FreeSurfer, and MRIQC configs into the configurable BIDS-study project layout introduced by PennLINC/babs#369
- install input datasets beneath `sourcedata/` and standardize participant-selection flag spelling
- add `--session-label` to generated configs only for session-level projects
- make post-processing discover both `.babs/output_ria` and the legacy `output_ria`
- document the layout and add a regression script for rendered configuration behavior

## Why

The wrappers and post-processing assumed BABS's legacy `analysis/`, `input_ria/`, and `output_ria/` layout. Session-level runs also did not configure `$SESSION_SELECTION_FLAG`, so each scheduled session job could invoke the BIDS App without the session identity. Adding that placeholder unconditionally would break subject jobs because BABS does not define `$sesid` there.

## Impact

New projects use the project root as the analysis DataLad dataset and keep internal RIA stores under `.babs/`. Session projects receive the session label explicitly, while subject projects remain unchanged. Post-processing continues to support projects created with the legacy layout.

These session flags depend on the corresponding BIDS Apps accepting `--session-label` with BABS's positional `participant` invocation; the FreeSurfer and MRIQC updates are in ReproNim/freesurfer-nidm_bidsapp#8 and ReproNim/mriqc-nidm_bidsapp#11, with ANTs handled in the sibling rollout.

## Validation

- `bash -n` on all wrapper, shared, post-processing, and test scripts
- `bash tests/test_babs_pr369.sh`
- generated subject- and session-level scripts for all three configs against BABS PR #369 merge commit `2cc536a`
- verified configured root/`.babs` paths and legacy BABS defaults for all three configs
- `git diff --check`

`shellcheck` was not available in the validation environment.
