### PR TITLE
babs_common: add BABS_OUTPUT_DIR override for undated project paths

### DIFF
--- a/babs_common.sh
+++ b/babs_common.sh
@@ -245,6 +245,16 @@ babs_nidm_origin() {
 # space, and a project created there is invisible to anything reading the study.
 # Usage: babs_study_output_dir <dataset_name> <site_name> <app_name>
 babs_study_output_dir() {
+    # BABS_OUTPUT_DIR wins when set: it lets a run place the project at a fixed,
+    # undated path -- e.g. the canonical deliverable a site publishes -- without
+    # disturbing RUN_DATE, which still names the scratch run dir, the compute
+    # space, the log file and the SLURM job. Renaming after `babs init` is not a
+    # simple `mv`: babs bakes absolute paths into code/submit_job_template.yaml,
+    # so the final path has to be chosen up front.
+    if [ -n "${BABS_OUTPUT_DIR:-}" ]; then
+        echo "$BABS_OUTPUT_DIR"
+        return
+    fi
     echo "${DATALAD_SET_DIR}/${1}/site-${2}/derivatives/babs-${3}_${RUN_DATE}"
 }
 


### PR DESCRIPTION
## Why

`babs_study_output_dir()` always appends `_${RUN_DATE}` to the project path. RUN_DATE also names the scratch run dir, the compute space, the log file and the SLURM job, so it can't simply be blanked when a run needs to land at a fixed, undated path — e.g. the canonical `derivatives/babs-<app>` deliverable a site publishes. Renaming after `babs init` doesn't work either: babs bakes absolute paths into `code/submit_job_template.yaml`, so the final path has to be chosen up front.

## What

`BABS_OUTPUT_DIR`, when set, wins over the derived dated path. Unset keeps the existing behavior — additive and backward-compatible.

## Validation

First used for the 38-subject Caltech freesurfer-nidm final run (2026-08-27): the project landed at `derivatives/babs-freesurfer-nidm` exactly as specified, init/submit/merge all ran normally, and the run completed 38/38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)