### PR TITLE
ants: size cluster_resources from the first gate-passing run

### DIFF
--- a/config_ants-nidm.yaml
+++ b/config_ants-nidm.yaml
@@ -61,19 +61,19 @@ cluster_resources:
     # new BRANCH and no collision. Expect some jobs to need resubmission; that is
     # the trade for the extra nodes.
     #
-    # cpus/mem: PILOT VALUES, to be re-sized from measured MaxRSS/Elapsed once a
-    # subject completes (no correct ANTs run has finished through BABS yet). 16
-    # threads because joint label fusion registers 20 atlases; 48G because ITK
-    # allocates per-thread buffers and the earlier 32G was sized for 8 threads.
-    # time: 12:00:00 retained -- the partition now allows up to 2 days, but the
-    # one completed (if wrongly-masked) run took 1h23m, so 12h is already ample
-    # and a shorter request schedules sooner.
+    # cpus/mem/time: sized from the first gate-passing run (aug27c pilot,
+    # job 21427403_1, sub-0051456): Elapsed 1:25:12, MaxRSS 17.9 GB at 16
+    # threads. 32G is ~1.8x measured headroom (JLF memory tracks brain-mask
+    # size, which varies by subject); 04:00:00 is ~2.8x measured and
+    # schedules much sooner than the old 12h request. The wrongly-masked
+    # aug26/aug27 runs needed 25.5 GB because they fused over whole-head
+    # masks; a correct mask needs less.
     customized_text: |
         #SBATCH --partition=mit_preemptable
         #SBATCH --no-requeue
         #SBATCH --cpus-per-task=16
-        #SBATCH --mem=48G
-        #SBATCH --time=12:00:00
+        #SBATCH --mem=32G
+        #SBATCH --time=04:00:00
         #SBATCH --job-name=ants-nidm_bidsapp_${RUN_DATE}
 # Necessary commands to be run first. This runs on the COMPUTE side
 # (participant_job.sh), which only needs datalad/git-annex/apptainer -- not the


### PR DESCRIPTION
Sizes `config_ants-nidm.yaml`'s `cluster_resources` from measured usage instead of guesses.

The previous `48G` / `12:00:00` were pilot placeholders, informed only by runs
that fused over whole-head masks (a masking bug since fixed) and therefore
overstated memory.

**Measurement** — first gate-passing run, aug27c pilot, `sub-0051456`
(SLURM job `21427403_1`), confirmed via `sacct`:

| metric | value |
|---|---|
| Elapsed | `01:25:12` |
| MaxRSS | `17895620K` (≈17.1 GiB) |
| AllocCPUS | 16 |

**New values**

- `--mem=32G` — ~1.9× measured. Joint label fusion memory tracks brain-mask
  size, which varies by subject, so the headroom is deliberate rather than tight.
- `--time=04:00:00` — ~2.8× measured, and a much shorter request schedules
  sooner on `mit_preemptable` than the old 12h.
- `--cpus-per-task=16` unchanged (20-atlas JLF).

The surrounding comment block is updated to cite the measurement rather than
the guess, so the next person resizing this knows where the numbers came from.

No behavioral change to any script — this is a resource request only.
